### PR TITLE
feat:카테고리 삭제 기능 추가

### DIFF
--- a/src/main/java/com/study/bookstore/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/study/bookstore/domain/category/controller/CategoryController.java
@@ -3,6 +3,7 @@ package com.study.bookstore.domain.category.controller;
 import com.study.bookstore.domain.category.dto.req.CreateCategoryReqDto;
 import com.study.bookstore.domain.category.dto.req.UpdateCategoryReqDto;
 import com.study.bookstore.domain.category.service.CreateCategoryService;
+import com.study.bookstore.domain.category.service.DeleteCategoryService;
 import com.study.bookstore.domain.category.service.UpdateCategoryService;
 import com.study.bookstore.domain.user.entity.User;
 import com.study.bookstore.domain.user.entity.UserType;
@@ -12,6 +13,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -27,7 +29,7 @@ public class CategoryController {
 
   private final CreateCategoryService createCategoryService;
   private final UpdateCategoryService updateCategoryService;
-
+  private final DeleteCategoryService deleteCategoryService;
 
   @Operation(summary = "카테고리 추가")
   @PostMapping
@@ -63,5 +65,24 @@ public class CategoryController {
       return ResponseEntity.ok().body("카테고리 수정 완료");
     }
   }
+  @Operation(summary = "카테고리 삭제")
+  @DeleteMapping("/delete/{categoryId}")
+  public ResponseEntity<String> deleteCategory(@PathVariable Long categoryId, HttpSession session){
+    User user = (User) session.getAttribute("user");
+    if (user == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요");
+    }
+    UserType userType = user.getUserType();
+    if (userType == null || userType == UserType.USER) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한이 없습니다.");
+    } else {
+      deleteCategoryService.deleteCategory(categoryId);
+      return ResponseEntity.ok().body("카테고리 삭제 완료");
 
-}
+      }
+    }
+
+  }
+
+
+

--- a/src/main/java/com/study/bookstore/domain/category/entity/Category.java
+++ b/src/main/java/com/study/bookstore/domain/category/entity/Category.java
@@ -3,6 +3,7 @@ package com.study.bookstore.domain.category.entity;
 import com.study.bookstore.domain.book.entity.Book;
 import com.study.bookstore.domain.category.dto.req.UpdateCategoryReqDto;
 import com.study.bookstore.global.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -34,7 +35,7 @@ public class Category extends BaseTimeEntity {
   private String categoryName;
 
   //카테고리가 1, 여러 책이 속할 수 있다. Book 클래스의 category 필드와 연결된다는 의미
-  @OneToMany(mappedBy = "category")
+  @OneToMany(mappedBy = "category", cascade = CascadeType.REMOVE)
   private List<Book> books = new ArrayList<>();// 해당 카테고리에 속하는 책 목록
 
   public void setCategoryName(String categoryName){

--- a/src/main/java/com/study/bookstore/domain/category/service/DeleteCategoryService.java
+++ b/src/main/java/com/study/bookstore/domain/category/service/DeleteCategoryService.java
@@ -1,0 +1,26 @@
+package com.study.bookstore.domain.category.service;
+
+import com.study.bookstore.domain.category.entity.Category;
+import com.study.bookstore.domain.category.entity.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+
+public class DeleteCategoryService {
+
+  private final CategoryRepository categoryRepository;
+
+  public void deleteCategory(Long categoryId){
+    Category category = categoryRepository.findById(categoryId)
+        .orElseThrow(()-> new IllegalArgumentException("해당 카테고리가 없습니다."));
+
+    categoryRepository.delete(category);
+  }
+
+
+
+}


### PR DESCRIPTION
## 📝 설명 (Description)
카테고리 삭제 기능을 추가하여 사용자가 특정 카테고리를 삭제할 수 있도록 변경했다. 카테고리 삭제 시 해당 카테고리에 속한 책들도 함께 삭제되어 데이터 일관성을 유지한다.

--- 

## 🔄 변경 사항 (Changes)
 카테고리 삭제 기능 : 사용자가 특정 카테고리를 삭제할 수 있도록 구현
 연관된 책 삭제 기능 : 카테고리가 삭제될 때 해당 카테고리에 속한 책들도 함께 삭제

---

## 📌 참고 사항 (Additional Notes)
카테고리 삭제 시 연관된 책 삭제 기능은 데이터베이스에서 ON DELETE CASCADE 옵션을 통해 설정
