### PR TITLE
Feat: order, orderItem 추가 기능

### DIFF
--- a/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
@@ -1,0 +1,37 @@
+package com.study.bookstore.domain.order.controller;
+
+import com.study.bookstore.domain.order.entity.PaymentMethod;
+import com.study.bookstore.domain.order.service.CreateOrderService;
+import com.study.bookstore.domain.user.entity.User;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/order")
+@RequiredArgsConstructor
+public class OrderController {
+
+  private final CreateOrderService createOrderService;
+
+  @PostMapping("/cartOrder")
+  public ResponseEntity<?> createOrder(PaymentMethod paymentMethod, HttpSession session) {
+    try {
+      User user = (User) session.getAttribute("user");
+
+      if (user == null) {
+        return ResponseEntity.badRequest().body("로그인해주세요.");
+      }
+
+      createOrderService.createOrder(paymentMethod, session, user);
+
+      return ResponseEntity.ok().body("주문이 완료되었습니다.");
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body("??");
+    }
+  }
+}

--- a/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.study.bookstore.domain.order.controller;
 
 import com.study.bookstore.domain.order.entity.PaymentMethod;
 import com.study.bookstore.domain.order.service.CreateOrderService;
+import com.study.bookstore.domain.orderItem.service.CreateOrderItemService;
 import com.study.bookstore.domain.user.entity.User;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
   private final CreateOrderService createOrderService;
+  private final CreateOrderItemService createOrderItemService;
 
   @PostMapping("/cartOrder")
   public ResponseEntity<?> createOrder(PaymentMethod paymentMethod, HttpSession session) {
@@ -27,7 +29,11 @@ public class OrderController {
         return ResponseEntity.badRequest().body("로그인해주세요.");
       }
 
-      createOrderService.createOrder(paymentMethod, session, user);
+      Long orderId = createOrderService.createOrder(paymentMethod, session, user);
+
+      createOrderItemService.createOrderItems(orderId, session);
+
+      session.removeAttribute("cart");
 
       return ResponseEntity.ok().body("주문이 완료되었습니다.");
     } catch (Exception e) {

--- a/src/main/java/com/study/bookstore/domain/order/entity/Order.java
+++ b/src/main/java/com/study/bookstore/domain/order/entity/Order.java
@@ -1,0 +1,76 @@
+package com.study.bookstore.domain.order.entity;
+
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import com.study.bookstore.domain.user.entity.User;
+import com.study.bookstore.global.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "orders")
+public class Order extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "order_id")
+  private Long orderId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  // 한 명의 유저는 여러개의 주문을 가질 수 있다.
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "total_amount", nullable = false)
+  private int totalAmount;
+
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  private Status status = Status.PENDING;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "payment_method", nullable = false)
+  private PaymentMethod paymentMethod;
+
+  @Column(name = "payment_date")
+  private LocalDateTime paymentDate;
+
+  @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+  // 하나의 order는 여러개의 orderItem을 가질 수 있다.
+  // mappedBy = "order" : orderItems에 있는 order필드에 의해 매핑됨
+  // cascade = CascadeType.ALL : order가 저장,삭제될 때 orderItem도 같이 저장,삭제
+  private List<OrderItem> orderItems;
+
+  public void createOrder(User user, PaymentMethod paymentMethod) {
+    this.user = user;
+    this.totalAmount = -1;
+    this.paymentMethod = paymentMethod;
+  }
+
+  public void addOrderItem(List<OrderItem> orderItems) {
+    this.orderItems.addAll(orderItems);
+    for (OrderItem orderItem : orderItems) {
+      orderItem.addOrder(this);
+    }
+  }
+}

--- a/src/main/java/com/study/bookstore/domain/order/entity/PaymentMethod.java
+++ b/src/main/java/com/study/bookstore/domain/order/entity/PaymentMethod.java
@@ -1,0 +1,7 @@
+package com.study.bookstore.domain.order.entity;
+
+public enum PaymentMethod {
+  CREDIT_CARD,      // 신용카드
+  BANK_TRANSFER,    // 계좌이체
+  MOBILE_PAYMENT    // 모바일 결제
+}

--- a/src/main/java/com/study/bookstore/domain/order/entity/Status.java
+++ b/src/main/java/com/study/bookstore/domain/order/entity/Status.java
@@ -1,0 +1,20 @@
+package com.study.bookstore.domain.order.entity;
+
+public enum Status {
+  PENDING,
+  // 결제 대기 (유저가 주문을 한 직후, 결제 전 재고 확인 등을 위한 임시 상태)
+  READY_FOR_PAYMENT,
+  // 결제 요청 (확인 후 결제를 진행할 준비가 된 상태)
+  PAYMENT_COMPLETED,
+  // 결제 완료 (결제가 정상적으로 처리된 상태)
+  PAYMENT_FAILED,
+  // 결제 실패 (재고나 금액 등의 문제로 결제가 실패한 상태)
+  CANCELLED,
+  // 결제 취소 (사용자의 요청으로 결제가 취소된 상태)
+  PREPARING_FOR_SHIPPING,
+  // 배송 준비중 (결제 완료 후 배송 준비중인 상태)
+  SHIPPING,
+  // 배송중 (결제 완료 후 다음날 배송중 상태)
+  DELIVERED
+  // 배송 완료 (2-3일차 배송 완료 상태)
+}

--- a/src/main/java/com/study/bookstore/domain/order/entity/repository/OrderRepository.java
+++ b/src/main/java/com/study/bookstore/domain/order/entity/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.study.bookstore.domain.order.entity.repository;
+
+import com.study.bookstore.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/study/bookstore/domain/order/service/CreateOrderService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/CreateOrderService.java
@@ -1,0 +1,72 @@
+package com.study.bookstore.domain.order.service;
+
+import com.study.bookstore.domain.book.entity.Book;
+import com.study.bookstore.domain.book.entity.repository.BookRepository;
+import com.study.bookstore.domain.order.entity.Order;
+import com.study.bookstore.domain.order.entity.PaymentMethod;
+import com.study.bookstore.domain.order.entity.repository.OrderRepository;
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import com.study.bookstore.domain.orderItem.entity.repository.OrderItemRepository;
+import com.study.bookstore.domain.user.entity.User;
+import jakarta.servlet.http.HttpSession;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class CreateOrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderItemRepository orderItemRepository;
+  private final BookRepository bookRepository;
+
+  public void createOrder(PaymentMethod paymentMethod, HttpSession session, User user)
+      throws Exception {
+    try {
+      Order order = Order.builder()
+          .user(user)
+          .paymentMethod(paymentMethod)
+          .totalAmount(-1)
+          .build();
+/*
+      Map<Long, Integer> cart = (Map<Long, Integer>) session.getAttribute("cart");
+      if (cart == null) {
+        throw new IllegalArgumentException("장바구니가 비어있습니다.");
+      }
+
+      List<OrderItem> orderItems = new ArrayList<>();
+
+      for (Map.Entry<Long, Integer> entry : cart.entrySet()) {
+        Long bookId = entry.getKey();
+        int quantity = entry.getValue();
+
+        Book book = bookRepository.findById(bookId)
+            .orElseThrow(() -> new NoSuchElementException("해당 ID의 책은 존재하지 않습니다."));
+
+        OrderItem orderItem = OrderItem.builder()
+            .book(book)
+            .quantity(quantity)
+            .itemPrice(book.getPrice())
+            .order(order)
+            .build();
+
+        orderItems.add(orderItem);
+      }
+
+      order.addOrderItem(orderItems);
+*/
+      orderRepository.save(order);
+    } catch (Exception e) {
+      throw new Exception("");
+    }
+
+
+  }
+}

--- a/src/main/java/com/study/bookstore/domain/order/service/CreateOrderService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/CreateOrderService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.aspectj.weaver.ast.Or;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +28,7 @@ public class CreateOrderService {
   private final OrderItemRepository orderItemRepository;
   private final BookRepository bookRepository;
 
-  public void createOrder(PaymentMethod paymentMethod, HttpSession session, User user)
+  public Long createOrder(PaymentMethod paymentMethod, HttpSession session, User user)
       throws Exception {
     try {
       Order order = Order.builder()
@@ -62,11 +63,13 @@ public class CreateOrderService {
 
       order.addOrderItem(orderItems);
 */
-      orderRepository.save(order);
+      Order saveOrder = orderRepository.save(order);
+
+      return saveOrder.getOrderId();
+      // 저장한 order의 id값을 가져옴
+
     } catch (Exception e) {
       throw new Exception("");
     }
-
-
   }
 }

--- a/src/main/java/com/study/bookstore/domain/orderItem/entity/OrderItem.java
+++ b/src/main/java/com/study/bookstore/domain/orderItem/entity/OrderItem.java
@@ -1,0 +1,52 @@
+package com.study.bookstore.domain.orderItem.entity;
+
+import com.study.bookstore.domain.book.entity.Book;
+import com.study.bookstore.domain.order.entity.Order;
+import com.study.bookstore.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "orderItems")
+public class OrderItem extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "order_item_id")
+  private Long orderItemId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  // 하나의 order는 여러개의 orderItem을 가질 수 있다.
+  @JoinColumn(name = "order_id", nullable = false)
+  private Order order;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  // 하나의 book은 여러개의 orderItem을 가질 수 있다.
+  @JoinColumn(name = "book_id", nullable = false)
+  private Book book;
+
+  @Column(nullable = false)
+  private int quantity;
+
+  @Column(name = "item_price", nullable = false)
+  private int itemPrice;
+
+  public void addOrder(Order order) {
+    this.order = order;
+  }
+}

--- a/src/main/java/com/study/bookstore/domain/orderItem/entity/repository/OrderItemRepository.java
+++ b/src/main/java/com/study/bookstore/domain/orderItem/entity/repository/OrderItemRepository.java
@@ -1,0 +1,10 @@
+package com.study.bookstore.domain.orderItem.entity.repository;
+
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+}

--- a/src/main/java/com/study/bookstore/domain/orderItem/service/CreateOrderItemService.java
+++ b/src/main/java/com/study/bookstore/domain/orderItem/service/CreateOrderItemService.java
@@ -1,0 +1,59 @@
+package com.study.bookstore.domain.orderItem.service;
+
+import com.study.bookstore.domain.book.entity.Book;
+import com.study.bookstore.domain.book.entity.repository.BookRepository;
+import com.study.bookstore.domain.order.entity.Order;
+import com.study.bookstore.domain.order.entity.repository.OrderRepository;
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import com.study.bookstore.domain.orderItem.entity.repository.OrderItemRepository;
+import jakarta.servlet.http.HttpSession;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class CreateOrderItemService {
+
+  private final OrderRepository orderRepository;
+  private final BookRepository bookRepository;
+  private final OrderItemRepository orderItemRepository;
+
+  public void createOrderItems(Long orderId, HttpSession session) {
+    Order order = orderRepository.findById(orderId).orElse(null);
+
+    if (order == null) {
+      throw new NoSuchElementException("해당 ID의 주문이 존재하지 않습니다.");
+    }
+
+    Map<Long, Integer> cart = (Map<Long, Integer>) session.getAttribute("cart");
+    if (cart == null) {
+      throw new IllegalArgumentException("장바구니가 비어있습니다.");
+    }
+
+    List<OrderItem> orderItems = new ArrayList<>();
+
+    for (Map.Entry<Long, Integer> entry : cart.entrySet()) {
+      Long bookId = entry.getKey();
+      int quantity = entry.getValue();
+
+      Book book = bookRepository.findById(bookId)
+          .orElseThrow(() -> new NoSuchElementException("해당 ID의 책은 존재하지 않습니다."));
+
+      OrderItem orderItem = OrderItem.builder()
+          .order(order)
+          .book(book)
+          .quantity(quantity)
+          .itemPrice(book.getPrice())
+          .build();
+
+      orderItemRepository.save(orderItem);
+    }
+  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
유저가 장바구니에 담아둔 상품들을 한꺼번에 주문할 수 있는 기능입니다.
주문시 order와 orderItem 둘 다 생성되도록 만들었습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 변경사항 1 : 유저가 장바구니에 담아둔 상품들을 주문하는 기능. 주문을 하기 위해서 결제방법을 선택해야합니다.
- [ ] 변경사항 2 : order 추가 - 유저가 선택한 결제방법과 로그인된 유저 id를 이용해 order를 생성합니다.
                                                총 금액은 orderItem이 생성된 후 알 수 있으므로 임시로 '-1'의 값을 넣었습니다.
                                                주문 초반에는 결제상태는 '대기', 결제 일시는 'null'로 고정합니다.
- [ ] 변경사항 3 : orderItem 추가 - 생성된 order와 장바구니 세션에 담긴 cart 값을 이용해 orderItem을 생성합니다.
                                                       장바구니에는 여러 책이 담길 수 있으므로 반복문을 통해 장바구니에 담긴 
                                                       상품의 종류만큼 orderItem을 생성합니다.

---

## 📌 참고 사항 (Additional Notes)
추후 order의 총 금액 계산, 결제 일시 업데이트, 결제 상태 변경 등의 기능을 추가할 예정입니다.
결제와 관련된 추가적인 로직이나 재고 확인 등은 이후 코드에서 보완할 계획입니다.
