### PR TITLE
feat: 주문 상태 변경 로직 추가 (결제 대기 → 결제 요청)

### DIFF
--- a/src/main/java/com/study/bookstore/domain/book/entity/Book.java
+++ b/src/main/java/com/study/bookstore/domain/book/entity/Book.java
@@ -81,19 +81,21 @@ public class Book extends BaseTimeEntity {
   private LocalDateTime updatedDate;*/
 
 
- public void updateFrom(UpdateBookReqDto req) {
-   this.title = req.title();
-   this.author = req.author();
-   this.publisher = req.publisher();
-   this.price = req.price();
-   this.stock = req.stock();
-   this.publishedDate = req.publishedDate();
-   this.page = req.page();
-   this.category = req.category();
-   this.description = req.description();
-   this.isbn = req.isbn();
-   // updatedDate, createdDate는 JPA에서 자동으로 관리
- }
+  public void updateFrom(UpdateBookReqDto req) {
+    this.title = req.title();
+    this.author = req.author();
+    this.publisher = req.publisher();
+    this.price = req.price();
+    this.stock = req.stock();
+    this.publishedDate = req.publishedDate();
+    this.page = req.page();
+    this.category = req.category();
+    this.description = req.description();
+    this.isbn = req.isbn();
+    // updatedDate, createdDate는 JPA에서 자동으로 관리
+  }
 
-
+  public void buyBook(int quantity) {
+    this.stock -= quantity;
+  }
 }

--- a/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
@@ -7,11 +7,9 @@ import com.study.bookstore.domain.orderItem.service.CreateOrderItemService;
 import com.study.bookstore.domain.user.entity.User;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,16 +44,8 @@ public class OrderController {
       session.removeAttribute("cart");
       // 주문이 완료되면 장바구니 세션 삭제하기
 
-      // return ResponseEntity.ok().body("주문이 완료되었습니다.");
-
-      return ResponseEntity.status(HttpStatus.FOUND)
-          // http 상태코드 300번대는 리다이렉트
-          // HttpStatus.FOUND : http 상태코드 302
-          // 근데 302는 getmapping으로 가는거라 지금은 putmapping으로 가려고해서 맞지 않음
-          .header("Location", "/order/updateToReadyForPayment?orderId=" + orderId)
-          // "Location" : 표준 HTTP 헤더. 이 헤더에 이동할 경로를 담는다.
-          .build();
-          // 응답이 완성되어 만들어지고, 클라이언트에게 전송된다.
+      return ResponseEntity.ok().body("주문이 완료되었습니다.");
+      // orderId를 가지고 @PutMapping("/updateToReadyForPayment")로 리다이렉트
 
     } catch (Exception e) {
       return ResponseEntity.badRequest().body(e.getMessage());
@@ -63,12 +53,13 @@ public class OrderController {
   }
 
   @PutMapping("/updateToReadyForPayment")
-  public ResponseEntity<?> updateStatus(@RequestParam Long orderId) {
+  public ResponseEntity<String> updateStatus(@RequestParam Long orderId) {
     try {
       updateOrderStatusService.updateStatus(orderId);
 
-      return ResponseEntity.ok().body("주문완");
+      return ResponseEntity.ok().body("이제 결제가 가능합니다.");
     } catch (Exception e) {
+      updateOrderStatusService.updateFail(orderId);
       return ResponseEntity.badRequest().body(e.getMessage());
     }
   }

--- a/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
@@ -2,14 +2,18 @@ package com.study.bookstore.domain.order.controller;
 
 import com.study.bookstore.domain.order.entity.PaymentMethod;
 import com.study.bookstore.domain.order.service.CreateOrderService;
+import com.study.bookstore.domain.order.service.UpdateOrderStatusService;
 import com.study.bookstore.domain.orderItem.service.CreateOrderItemService;
 import com.study.bookstore.domain.user.entity.User;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,9 +23,10 @@ public class OrderController {
 
   private final CreateOrderService createOrderService;
   private final CreateOrderItemService createOrderItemService;
+  private final UpdateOrderStatusService updateOrderStatusService;
 
   @PostMapping("/cartOrder")
-  public ResponseEntity<?> createOrder(PaymentMethod paymentMethod, HttpSession session) {
+  public ResponseEntity<String> createOrder(PaymentMethod paymentMethod, HttpSession session) {
     try {
       User user = (User) session.getAttribute("user");
 
@@ -29,15 +34,42 @@ public class OrderController {
         return ResponseEntity.badRequest().body("로그인해주세요.");
       }
 
-      Long orderId = createOrderService.createOrder(paymentMethod, session, user);
+      Long orderId = createOrderService.createOrder(paymentMethod, user);
+      // order 생성 후 생성된 orderId 반환
 
-      createOrderItemService.createOrderItems(orderId, session);
+      int totalAmount = createOrderItemService.createOrderItems(orderId, session);
+      // orderId와 장바구니를 이용해 orderItem 생성 후 총 금액 반환
+
+      createOrderService.updateTotalAmount(orderId, totalAmount);
+      // order에 totalAmount 값 넣기
 
       session.removeAttribute("cart");
+      // 주문이 완료되면 장바구니 세션 삭제하기
 
-      return ResponseEntity.ok().body("주문이 완료되었습니다.");
+      // return ResponseEntity.ok().body("주문이 완료되었습니다.");
+
+      return ResponseEntity.status(HttpStatus.FOUND)
+          // http 상태코드 300번대는 리다이렉트
+          // HttpStatus.FOUND : http 상태코드 302
+          // 근데 302는 getmapping으로 가는거라 지금은 putmapping으로 가려고해서 맞지 않음
+          .header("Location", "/order/updateToReadyForPayment?orderId=" + orderId)
+          // "Location" : 표준 HTTP 헤더. 이 헤더에 이동할 경로를 담는다.
+          .build();
+          // 응답이 완성되어 만들어지고, 클라이언트에게 전송된다.
+
     } catch (Exception e) {
-      return ResponseEntity.badRequest().body("??");
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @PutMapping("/updateToReadyForPayment")
+  public ResponseEntity<?> updateStatus(@RequestParam Long orderId) {
+    try {
+      updateOrderStatusService.updateStatus(orderId);
+
+      return ResponseEntity.ok().body("주문완");
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
     }
   }
 }

--- a/src/main/java/com/study/bookstore/domain/order/entity/Order.java
+++ b/src/main/java/com/study/bookstore/domain/order/entity/Order.java
@@ -61,16 +61,11 @@ public class Order extends BaseTimeEntity {
   // cascade = CascadeType.ALL : order가 저장,삭제될 때 orderItem도 같이 저장,삭제
   private List<OrderItem> orderItems;
 
-  public void createOrder(User user, PaymentMethod paymentMethod) {
-    this.user = user;
-    this.totalAmount = -1;
-    this.paymentMethod = paymentMethod;
+  public void updateTotalAmount(int totalAmount) {
+    this.totalAmount = totalAmount;
   }
 
-  public void addOrderItem(List<OrderItem> orderItems) {
-    this.orderItems.addAll(orderItems);
-    for (OrderItem orderItem : orderItems) {
-      orderItem.addOrder(this);
-    }
+  public void updateStatus(Status status) {
+    this.status = status;
   }
 }

--- a/src/main/java/com/study/bookstore/domain/order/service/CreateOrderService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/CreateOrderService.java
@@ -25,51 +25,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateOrderService {
 
   private final OrderRepository orderRepository;
-  private final OrderItemRepository orderItemRepository;
-  private final BookRepository bookRepository;
 
-  public Long createOrder(PaymentMethod paymentMethod, HttpSession session, User user)
-      throws Exception {
+  public Long createOrder(PaymentMethod paymentMethod, User user) {
     try {
       Order order = Order.builder()
           .user(user)
           .paymentMethod(paymentMethod)
           .totalAmount(-1)
           .build();
-/*
-      Map<Long, Integer> cart = (Map<Long, Integer>) session.getAttribute("cart");
-      if (cart == null) {
-        throw new IllegalArgumentException("장바구니가 비어있습니다.");
-      }
 
-      List<OrderItem> orderItems = new ArrayList<>();
-
-      for (Map.Entry<Long, Integer> entry : cart.entrySet()) {
-        Long bookId = entry.getKey();
-        int quantity = entry.getValue();
-
-        Book book = bookRepository.findById(bookId)
-            .orElseThrow(() -> new NoSuchElementException("해당 ID의 책은 존재하지 않습니다."));
-
-        OrderItem orderItem = OrderItem.builder()
-            .book(book)
-            .quantity(quantity)
-            .itemPrice(book.getPrice())
-            .order(order)
-            .build();
-
-        orderItems.add(orderItem);
-      }
-
-      order.addOrderItem(orderItems);
-*/
       Order saveOrder = orderRepository.save(order);
 
       return saveOrder.getOrderId();
       // 저장한 order의 id값을 가져옴
 
     } catch (Exception e) {
-      throw new Exception("");
+      throw new RuntimeException(e.getMessage());
     }
+  }
+
+  public void updateTotalAmount(Long orderId, int totalAmount) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new NoSuchElementException("해당 ID의 주문이 존재하지 않습니다."));
+
+    order.updateTotalAmount(totalAmount);
+
+    orderRepository.save(order);
   }
 }

--- a/src/main/java/com/study/bookstore/domain/order/service/UpdateOrderStatusService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/UpdateOrderStatusService.java
@@ -38,7 +38,6 @@ public class UpdateOrderStatusService {
         int quantity = orderItem.getQuantity();
 
         if (book.getStock() < quantity) {
-          order.updateStatus(Status.PAYMENT_FAILED);
           throw new IllegalArgumentException("재고가 부족합니다.");
         }
 
@@ -47,7 +46,6 @@ public class UpdateOrderStatusService {
       }
 
       if (totalAmount != order.getTotalAmount()) {
-        order.updateStatus(Status.PAYMENT_FAILED);
         throw new IllegalStateException("금액이 일치하지 않습니다.");
       }
 
@@ -58,6 +56,15 @@ public class UpdateOrderStatusService {
       for (OrderItem orderItem : orderItems) {
         orderItem.getBook().buyBook(orderItem.getQuantity());
       }
+    }
+  }
+
+  public void updateFail(Long orderId) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new NoSuchElementException("해당 ID의 주문이 존재하지 않습니다."));
+
+    if (order.getStatus() == Status.PENDING) {
+      order.updateStatus(Status.PAYMENT_FAILED);
     }
   }
 }

--- a/src/main/java/com/study/bookstore/domain/order/service/UpdateOrderStatusService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/UpdateOrderStatusService.java
@@ -1,0 +1,63 @@
+package com.study.bookstore.domain.order.service;
+
+import com.study.bookstore.domain.book.entity.Book;
+import com.study.bookstore.domain.order.entity.Order;
+import com.study.bookstore.domain.order.entity.Status;
+import com.study.bookstore.domain.order.entity.repository.OrderRepository;
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import com.study.bookstore.domain.orderItem.entity.repository.OrderItemRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class UpdateOrderStatusService {
+
+  private final OrderRepository orderRepository;
+  private final OrderItemRepository orderItemRepository;
+
+  public void updateStatus(Long orderId) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new NoSuchElementException("해당 ID의 주문이 존재하지 않습니다."));
+
+    if (order.getStatus() == Status.PENDING) {
+    // order의 현재 상태가 PENDING(결제대기)상태인지 확인
+
+      List<OrderItem> orderItems = orderItemRepository.findAllByOrder_orderId(orderId);
+
+      int totalAmount = 0;
+
+      for (OrderItem orderItem : orderItems) {
+
+        // 재고 확인
+        Book book = orderItem.getBook();
+        int quantity = orderItem.getQuantity();
+
+        if (book.getStock() < quantity) {
+          order.updateStatus(Status.PAYMENT_FAILED);
+          throw new IllegalArgumentException("재고가 부족합니다.");
+        }
+
+        // 금액 확인
+        totalAmount += book.getPrice() * quantity;
+      }
+
+      if (totalAmount != order.getTotalAmount()) {
+        order.updateStatus(Status.PAYMENT_FAILED);
+        throw new IllegalStateException("금액이 일치하지 않습니다.");
+      }
+
+      // 재고, 금액 확인 후 주문이 가능하다면 '결제 대기' -> '결제 요청'으로 상태 변경
+      order.updateStatus(Status.READY_FOR_PAYMENT);
+
+      // 책 재고 --해주기
+      for (OrderItem orderItem : orderItems) {
+        orderItem.getBook().buyBook(orderItem.getQuantity());
+      }
+    }
+  }
+}

--- a/src/main/java/com/study/bookstore/domain/orderItem/entity/OrderItem.java
+++ b/src/main/java/com/study/bookstore/domain/orderItem/entity/OrderItem.java
@@ -45,8 +45,4 @@ public class OrderItem extends BaseTimeEntity {
 
   @Column(name = "item_price", nullable = false)
   private int itemPrice;
-
-  public void addOrder(Order order) {
-    this.order = order;
-  }
 }

--- a/src/main/java/com/study/bookstore/domain/orderItem/entity/repository/OrderItemRepository.java
+++ b/src/main/java/com/study/bookstore/domain/orderItem/entity/repository/OrderItemRepository.java
@@ -1,10 +1,12 @@
 package com.study.bookstore.domain.orderItem.entity.repository;
 
 import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
+  List<OrderItem> findAllByOrder_orderId(Long orderId);
 }

--- a/src/main/java/com/study/bookstore/domain/orderItem/service/CreateOrderItemService.java
+++ b/src/main/java/com/study/bookstore/domain/orderItem/service/CreateOrderItemService.java
@@ -37,7 +37,6 @@ public class CreateOrderItemService {
       throw new IllegalArgumentException("장바구니가 비어있습니다.");
     }
 
-    List<OrderItem> orderItems = new ArrayList<>();
     int totalAmount = 0;
 
     for (Map.Entry<Long, Integer> entry : cart.entrySet()) {

--- a/src/main/java/com/study/bookstore/domain/orderItem/service/CreateOrderItemService.java
+++ b/src/main/java/com/study/bookstore/domain/orderItem/service/CreateOrderItemService.java
@@ -25,7 +25,7 @@ public class CreateOrderItemService {
   private final BookRepository bookRepository;
   private final OrderItemRepository orderItemRepository;
 
-  public void createOrderItems(Long orderId, HttpSession session) {
+  public int createOrderItems(Long orderId, HttpSession session) {
     Order order = orderRepository.findById(orderId).orElse(null);
 
     if (order == null) {
@@ -38,6 +38,7 @@ public class CreateOrderItemService {
     }
 
     List<OrderItem> orderItems = new ArrayList<>();
+    int totalAmount = 0;
 
     for (Map.Entry<Long, Integer> entry : cart.entrySet()) {
       Long bookId = entry.getKey();
@@ -53,7 +54,11 @@ public class CreateOrderItemService {
           .itemPrice(book.getPrice())
           .build();
 
+      totalAmount += book.getPrice() * quantity;
+
       orderItemRepository.save(orderItem);
     }
+
+    return totalAmount;
   }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
유저가 장바구니에 담아둔 상품을 주문하는 과정에서 주문의 총 금액을 임시 값인 -1이 아닌 정확하게 계산하여 넣었고,
재고와 금액 확인 후 주문 상태를 결제 대기에서 결제 요청으로 변경하는 기능을 추가했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 변경사항 1 : 주문 총 금액 설정 - orderItem에 있는 책의 단가와 수량을 통해 총 금액을 계산하여 그 값을 order에 넣음
- [ ] 변경사항 2 : 주문 상태 자동 변경 - 주문시 기본 상태는 '결제 대기'인데 이 상태에서 재고와, 금액을 확인하여
                            결제가 가능한 상태이면 '결제 요청'으로, 재고부족이나 금액 불일치로 결제가 불가능하면 '결제 실패'로
                            상태가 변경됩니다. 또한 결제 요청으로 바뀌면 책의 재고도 --하도록 기능을 넣었습니다.

---

## 📌 참고 사항 (Additional Notes)
결제 완료 및 이후의 상태 변경은 스케줄링 기능을 통해 특정 날짜에 맞춰 상태가 자동으로 업데이트되도록 할 예정입니다.
