### PR TITLE
feat: 주문 취소 기능 구현

### DIFF
--- a/src/main/java/com/study/bookstore/domain/book/entity/Book.java
+++ b/src/main/java/com/study/bookstore/domain/book/entity/Book.java
@@ -95,7 +95,13 @@ public class Book extends BaseTimeEntity {
     // updatedDate, createdDate는 JPA에서 자동으로 관리
   }
 
+  // 책 주문시 재고 -- (결제 대기 -> 결제요청으로 상태가 변경될 때)
   public void buyBook(int quantity) {
     this.stock -= quantity;
+  }
+
+  // 주문 취소시 재고 ++ (결제취소로 상태가 변경될 때)
+  public void returnBook(int quantity) {
+    this.stock += quantity;
   }
 }

--- a/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.study.bookstore.domain.order.controller;
 
 import com.study.bookstore.domain.order.entity.PaymentMethod;
+import com.study.bookstore.domain.order.service.CancelOrderService;
 import com.study.bookstore.domain.order.service.CreateOrderService;
 import com.study.bookstore.domain.order.service.UpdateOrderStatusService;
 import com.study.bookstore.domain.orderItem.service.CreateOrderItemService;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +27,7 @@ public class OrderController {
   private final CreateOrderService createOrderService;
   private final CreateOrderItemService createOrderItemService;
   private final UpdateOrderStatusService updateOrderStatusService;
+  private final CancelOrderService cancelOrderService;
 
   @Operation(summary = "주문 생성", description = "장바구니에 담긴 상품들을 주문합니다.")
   @PostMapping("/cartOrder")
@@ -81,6 +84,24 @@ public class OrderController {
     } catch (Exception e) {
       // 만약 결제가 실패하거나 정해진 시간안에 결제를 하지 않은 경우에는 결제실패상태로 변경
       updateOrderStatusService.updateFail(orderId);
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @Operation(summary = "주문취소", description = "유저의 요청으로 주문이 자동으로 취소됩니다.")
+  @PutMapping("/cancelOrder/{orderId}")
+  public ResponseEntity<String> cancelOrder(@PathVariable Long orderId, HttpSession session) {
+    try {
+      User user = (User) session.getAttribute("user");
+
+      if (user == null) {
+        return ResponseEntity.badRequest().body("로그인 해주세요.");
+      }
+
+      cancelOrderService.cancelOrder(orderId, user);
+
+      return ResponseEntity.ok().body("주문이 취소되었습니다.");
+    } catch (Exception e) {
       return ResponseEntity.badRequest().body(e.getMessage());
     }
   }

--- a/src/main/java/com/study/bookstore/domain/order/service/CancelOrderService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/CancelOrderService.java
@@ -1,0 +1,60 @@
+package com.study.bookstore.domain.order.service;
+
+import com.study.bookstore.domain.order.entity.Order;
+import com.study.bookstore.domain.order.entity.Status;
+import com.study.bookstore.domain.order.entity.repository.OrderRepository;
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import com.study.bookstore.domain.orderItem.entity.repository.OrderItemRepository;
+import com.study.bookstore.domain.user.entity.User;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class CancelOrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderItemRepository orderItemRepository;
+
+  public void cancelOrder(Long orderId, User user) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new NoSuchElementException("해당 ID의 주문이 존재하지 않습니다."));
+
+    if (!order.getUser().getUserId().equals(user.getUserId())) {
+      throw new RuntimeException("해당 주문에 대한 권한이 없습니다.");
+    }
+
+    if (order.getStatus() == Status.CANCELLED) {
+      throw new RuntimeException("이미 취소된 주문입니다.");
+    }
+
+    if (order.getStatus() == Status.PAYMENT_FAILED) {
+      throw new RuntimeException("결제실패 처리된 주문입니다.");
+    }
+
+    if (order.getStatus() == Status.PREPARING_FOR_SHIPPING ||
+        order.getStatus() == Status.SHIPPING ||
+        order.getStatus() == Status.DELIVERED) {
+      throw new RuntimeException("배송진행 이후에는 취소가 불가능합니다.");
+    }
+
+    if (order.getStatus() == Status.READY_FOR_PAYMENT ||
+        order.getStatus() == Status.PAYMENT_COMPLETED) {
+
+
+      List<OrderItem> orderItems = orderItemRepository.findAllByOrder_orderId(orderId);
+
+      for (OrderItem orderItem : orderItems) {
+        orderItem.getBook().returnBook(orderItem.getQuantity());
+      }
+    }
+
+    // 결제 대기상태에서는 아직 재고가 차감되지 않았으므로 상태만 변경하면 된다
+
+    order.updateStatus(Status.CANCELLED);
+  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
유저가 자신의 주문을 취소할 수 있는 기능입니다.
주문 상태에 따라 취소 가능 여부를 결정하고, 상태에 맞는 메시지를 유저에게 전달합니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 변경사항 1 : 유저가 자신의 주문 중 취소를 원하는 orderId를 입력하면 주문상태에 따라 취소여부가 결정됩니다.
- [ ] 변경사항 2 : 주문 상태에 따라 여러 다른 메시지를 유저에게 보냅니다.
                             1. 주문 취소 상태일 때 - 이미 취소된 주문이라고 알려줌
                             2. 주문 실패 상태일 때 - 결제실패 처리된 주문이라고 알려줌
                             3. 배송준비중, 배송중, 배송완료 상태일 때 - 배송 진행 이후에는 취소할 수 없다고 알려줌
                             4. 결제 요청, 결제 완료 상태일 때 - 주문취소 상태로 변경 후 책 재고를 다시 돌려놓음
                             5. 결제 대기 상태일 때 - 주문취소 상태로 변경 (결제 대기상태에서는 재고 변동이 없다)

---

## 📌 참고 사항 (Additional Notes)

