### PR TITLE
feat: 유저별 주문 목록 조회 기능

### DIFF
--- a/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
@@ -3,6 +3,7 @@ package com.study.bookstore.domain.order.controller;
 import com.study.bookstore.domain.order.entity.PaymentMethod;
 import com.study.bookstore.domain.order.service.CancelOrderService;
 import com.study.bookstore.domain.order.service.CreateOrderService;
+import com.study.bookstore.domain.order.service.GetOrderListService;
 import com.study.bookstore.domain.order.service.UpdateOrderStatusService;
 import com.study.bookstore.domain.orderItem.service.CreateOrderItemService;
 import com.study.bookstore.domain.user.entity.User;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,6 +30,7 @@ public class OrderController {
   private final CreateOrderItemService createOrderItemService;
   private final UpdateOrderStatusService updateOrderStatusService;
   private final CancelOrderService cancelOrderService;
+  private final GetOrderListService getOrderListService;
 
   @Operation(summary = "주문 생성", description = "장바구니에 담긴 상품들을 주문합니다.")
   @PostMapping("/cartOrder")
@@ -101,6 +104,29 @@ public class OrderController {
       cancelOrderService.cancelOrder(orderId, user);
 
       return ResponseEntity.ok().body("주문이 취소되었습니다.");
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @Operation(summary = "주문 목록 조회", description = "유저의 주문 내역을 조회합니다.")
+  @GetMapping("/getOrderList")
+  public ResponseEntity<?> gerOrderList(
+      @RequestParam(defaultValue = "0") int pageNo,
+      @RequestParam(defaultValue = "10") int pageSize,
+      @RequestParam(defaultValue = "createdDate") String sortBy,
+      @RequestParam(defaultValue = "DESC") String direction,
+      HttpSession session) {
+    try {
+      User user = (User) session.getAttribute("user");
+
+      if (user == null) {
+        return ResponseEntity.badRequest().body("로그인 해주세요");
+      }
+
+      return ResponseEntity.ok().body(
+          getOrderListService.getOrderList(
+              pageNo, pageSize, sortBy, direction, user.getUserId()).getContent());
     } catch (Exception e) {
       return ResponseEntity.badRequest().body(e.getMessage());
     }

--- a/src/main/java/com/study/bookstore/domain/order/dto/resp/GetOrderListRespDto.java
+++ b/src/main/java/com/study/bookstore/domain/order/dto/resp/GetOrderListRespDto.java
@@ -1,0 +1,22 @@
+package com.study.bookstore.domain.order.dto.resp;
+
+import com.study.bookstore.domain.order.entity.Order;
+import com.study.bookstore.domain.order.entity.Status;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record GetOrderListRespDto(
+    Long orderId,
+    Status status,
+    LocalDateTime createdDate
+) {
+
+  public static GetOrderListRespDto from(Order order) {
+    return GetOrderListRespDto.builder()
+        .orderId(order.getOrderId())
+        .status(order.getStatus())
+        .createdDate(order.getCreatedDate())
+        .build();
+  }
+}

--- a/src/main/java/com/study/bookstore/domain/order/entity/repository/OrderRepository.java
+++ b/src/main/java/com/study/bookstore/domain/order/entity/repository/OrderRepository.java
@@ -3,6 +3,8 @@ package com.study.bookstore.domain.order.entity.repository;
 import com.study.bookstore.domain.order.entity.Order;
 import com.study.bookstore.domain.order.entity.Status;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
   List<Order> findAllByStatus(Status status);
+
+  Page<Order> findAllByUser_userId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/study/bookstore/domain/order/service/GetOrderListService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/GetOrderListService.java
@@ -1,0 +1,28 @@
+package com.study.bookstore.domain.order.service;
+
+import com.study.bookstore.domain.order.dto.resp.GetOrderListRespDto;
+import com.study.bookstore.domain.order.entity.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class GetOrderListService {
+
+  private final OrderRepository orderRepository;
+
+  public Page<?> getOrderList(
+      int pageNo, int pageSize, String sortBy, String direction, Long userId) {
+    Pageable pageable = PageRequest
+        .of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+
+    return orderRepository.findAllByUser_userId(userId, pageable)
+        .map(GetOrderListRespDto::from);
+  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
유저별로 주문 목록을 조회할 수 있는 기능을 추가했습니다.
유저는 자신의 주문 내역을 페이지별로 조회할 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 변경사항 1 : 유저별 주문 목록 조회 - 로그인 한 유저는 자신의 주문들을 한눈에 볼 수 있습니다.
- [ ] 변경사항 2 : 페이징 및 정렬 기능 - 주문 목록을 페이지별로 확인할 수 있으며, 정렬 순서도 직접 지정할 수 있습니다.
---

## 📌 참고 사항 (Additional Notes)
