### PR TITLE
유저 리뷰 목록 확인

### DIFF
--- a/src/main/java/com/study/bookstore/domain/review/entity/repository/ReviewRepository.java
+++ b/src/main/java/com/study/bookstore/domain/review/entity/repository/ReviewRepository.java
@@ -6,6 +6,8 @@ import com.study.bookstore.domain.review.entity.Review;
 import com.study.bookstore.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
@@ -14,6 +16,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   Optional<Review> findByReviewIdAndUser(Long reviewId, User user); // 특정 유저가 특정 리뷰를 소유하는지 확인
   Optional<Review> findById(Long reviewId);//리뷰 아이디로 리뷰 찾기
   List<Review> findByBookId(Long bookId);
+  Page<Review> findByUser(User user, Pageable pageable); // 유저의 리뷰 목록을 페이지네이션으로 조회
 
 }
 

--- a/src/main/java/com/study/bookstore/domain/review/service/ListReviewService.java
+++ b/src/main/java/com/study/bookstore/domain/review/service/ListReviewService.java
@@ -1,5 +1,7 @@
 package com.study.bookstore.domain.review.service;
 
+import com.study.bookstore.domain.book.entity.Book;
+import com.study.bookstore.domain.book.entity.repository.BookRepository;
 import com.study.bookstore.domain.review.dto.resp.ReviewListRespDto;
 import com.study.bookstore.domain.review.entity.Review;
 import com.study.bookstore.domain.review.entity.repository.ReviewRepository;
@@ -14,10 +16,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ListReviewService {
     private final ReviewRepository reviewRepository;
+    private final BookRepository bookRepository;
 
    //책에 대한 리뷰 목록 조회
     public List<ReviewListRespDto> getReviewsForBook(Long bookId) {
-      //책에 해당하는 review들을 db에서 조회
+      // bookId로 Book 객체를 찾기
+      Book book = bookRepository.findById(bookId)
+          .orElseThrow(() -> new RuntimeException("Book not found"));
+
+      // Book 객체를 사용하여 리뷰 조회
       List<Review> reviews = reviewRepository.findByBookId(bookId);
 
       // Review 객체들을 ReviewListRespDto로 변환(엔티티 그대로 보내주면 보안상 문제)

--- a/src/main/java/com/study/bookstore/domain/user/controller/UserController.java
+++ b/src/main/java/com/study/bookstore/domain/user/controller/UserController.java
@@ -3,21 +3,29 @@ package com.study.bookstore.domain.user.controller;
 import com.study.bookstore.domain.user.dto.req.CreateUserReqDto;
 import com.study.bookstore.domain.user.dto.req.LoginUserReqDto;
 import com.study.bookstore.domain.user.dto.req.UpdateUserReqDto;
+import com.study.bookstore.domain.user.dto.resp.UserReviewListRespDto;
 import com.study.bookstore.domain.user.entity.User;
 import com.study.bookstore.domain.user.service.CreateUserService;
 import com.study.bookstore.domain.user.service.DeleteUserService;
+import com.study.bookstore.domain.user.service.GetUserReviewService;
 import com.study.bookstore.domain.user.service.LoginUserService;
 import com.study.bookstore.domain.user.service.UpdateUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "유저 API")
@@ -30,6 +38,7 @@ public class UserController {
   private final LoginUserService loginUserService;
   private final DeleteUserService deleteUserService;
   private final UpdateUserService updateUserService;
+  private final GetUserReviewService getUserReviewService;
 
   @Operation(summary = "유저생성", description = "입력한 정보로 유저를 생성합니다.(회원가입)")
   @PostMapping
@@ -101,5 +110,16 @@ public class UserController {
     } catch (Exception e) {
       return ResponseEntity.status(401).body(e.getMessage());
     }
+  }
+
+  @Operation(summary = "유저 리뷰 리스트 확인", description = "유저가 쓴 리뷰 목록 조회")
+  @GetMapping("/{userId}/reviews")
+  public Page<UserReviewListRespDto> getUserReviews(
+      @PathVariable Long userId,
+      @RequestParam(defaultValue = "1") int page, // 기본값을 1로 설정
+      @RequestParam(defaultValue = "10") int size  // 기본값을 10으로 설정
+  ) {
+    Pageable pageable = PageRequest.of(page - 1, size); // Spring은 0부터 시작하므로 page - 1
+    return getUserReviewService.getUserReview(userId, pageable);
   }
 }

--- a/src/main/java/com/study/bookstore/domain/user/dto/resp/UserReviewListRespDto.java
+++ b/src/main/java/com/study/bookstore/domain/user/dto/resp/UserReviewListRespDto.java
@@ -1,0 +1,13 @@
+package com.study.bookstore.domain.user.dto.resp;
+
+import java.time.LocalDateTime;
+
+public record UserReviewListRespDto(
+    Long reviewId,
+    Double rating,
+    String content,
+    Long bookId,
+    String author,
+    LocalDateTime createdDate
+) {
+}

--- a/src/main/java/com/study/bookstore/domain/user/entity/User.java
+++ b/src/main/java/com/study/bookstore/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.study.bookstore.domain.user.entity;
 
+import com.study.bookstore.domain.review.entity.Review;
 import com.study.bookstore.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,7 +9,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,9 +55,11 @@ public class User extends BaseTimeEntity {
   // userType은 입력하지않으면 자동으로 USER가 된다
   // 관리자의 경우에만 회원가입시 userType = ADMIN으로 적어주기
 
+  //orders 추가해야함
 
-  // 나중에 orders, reviews 추가해야함
-
+  //유저가 가진 리뷰 목록
+  @OneToMany(mappedBy = "user")
+  private List<Review> reviews;
 
   public void updateUser(String password, String nick, String address) {
     this.password = password;

--- a/src/main/java/com/study/bookstore/domain/user/service/GetUserReviewService.java
+++ b/src/main/java/com/study/bookstore/domain/user/service/GetUserReviewService.java
@@ -1,0 +1,48 @@
+package com.study.bookstore.domain.user.service;
+
+import com.study.bookstore.domain.review.dto.resp.ReviewListRespDto;
+import com.study.bookstore.domain.review.entity.Review;
+import com.study.bookstore.domain.review.entity.repository.ReviewRepository;
+import com.study.bookstore.domain.user.dto.resp.UserReviewListRespDto;
+import com.study.bookstore.domain.user.entity.User;
+import com.study.bookstore.domain.user.entity.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class GetUserReviewService {
+
+  private final UserRepository userRepository;
+  private final ReviewRepository reviewRepository;
+
+  public Page<UserReviewListRespDto> getUserReview(Long userId, Pageable pageable) {
+    //1.유저를 조회한다.
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+
+    //2.유저가 작성한 리뷰 목록을 페이지네이션으로 조회한다.
+    Page<Review> reviewPage = reviewRepository.findByUser(user, pageable);
+
+    //3.엔티티형식인 리뷰목록을 클라이언트에게 보여주기 위해 dto로 변환
+    Page<UserReviewListRespDto> reviewListRespDtos = reviewPage.map(review ->
+        new UserReviewListRespDto(
+            review.getReviewId(),
+            review.getRating(),  // rating은 이미 Double 타입이므로 캐스팅 필요 없음
+            review.getContent(),
+            review.getBook().getBookId(),
+            review.getBook().getAuthor(),
+            review.getCreatedDate()
+        )
+    );
+
+    //4.dto를 포함한 응답을 반환한다.
+    return reviewListRespDtos;
+  }
+}
+
+


### PR DESCRIPTION
## 📝 설명 (Description)
유저 리뷰 목록에 페이지네이션을 적용하여, 리뷰를 한 번에 모두 불러오는 대신, 페이지를 나누어 요청할 수 있도록 수정

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
유저 리뷰 목록 페이지네이션 적용: Pageable을 활용해 유저 리뷰 목록을 페이지 단위로 조회하도록 변경했습니다. 이제 페이지 번호와 크기를 요청 시 전달할 수 있습니다.


---

## 📌 참고 사항 (Additional Notes)
Pageable 매개변수를 사용하여 클라이언트에서 페이지 번호(page)와 크기(size)를 요청하면, 해당 페이지에 맞는 데이터만 반환
