### PR TITLE
feat: 주문 상세 조회 기능

### DIFF
--- a/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
+++ b/src/main/java/com/study/bookstore/domain/order/controller/OrderController.java
@@ -1,15 +1,18 @@
 package com.study.bookstore.domain.order.controller;
 
+import com.study.bookstore.domain.order.dto.resp.GetOrderListRespDto;
 import com.study.bookstore.domain.order.entity.PaymentMethod;
 import com.study.bookstore.domain.order.service.CancelOrderService;
 import com.study.bookstore.domain.order.service.CreateOrderService;
 import com.study.bookstore.domain.order.service.GetOrderListService;
+import com.study.bookstore.domain.order.service.GetOrderService;
 import com.study.bookstore.domain.order.service.UpdateOrderStatusService;
 import com.study.bookstore.domain.orderItem.service.CreateOrderItemService;
 import com.study.bookstore.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +34,7 @@ public class OrderController {
   private final UpdateOrderStatusService updateOrderStatusService;
   private final CancelOrderService cancelOrderService;
   private final GetOrderListService getOrderListService;
+  private final GetOrderService getOrderService;
 
   @Operation(summary = "주문 생성", description = "장바구니에 담긴 상품들을 주문합니다.")
   @PostMapping("/cartOrder")
@@ -127,6 +131,21 @@ public class OrderController {
       return ResponseEntity.ok().body(
           getOrderListService.getOrderList(
               pageNo, pageSize, sortBy, direction, user.getUserId()).getContent());
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @GetMapping("/getOrder/{orderId}")
+  public ResponseEntity<?> getOrder(@PathVariable Long orderId, HttpSession session) {
+    try {
+      User user = (User) session.getAttribute("user");
+
+      if (user == null) {
+        return ResponseEntity.badRequest().body("로그인 해주세요");
+      }
+
+      return ResponseEntity.ok().body(getOrderService.getOrder(orderId, user));
     } catch (Exception e) {
       return ResponseEntity.badRequest().body(e.getMessage());
     }

--- a/src/main/java/com/study/bookstore/domain/order/dto/resp/GetOrderRespDto.java
+++ b/src/main/java/com/study/bookstore/domain/order/dto/resp/GetOrderRespDto.java
@@ -1,0 +1,22 @@
+package com.study.bookstore.domain.order.dto.resp;
+
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import lombok.Builder;
+
+@Builder
+public record GetOrderRespDto(
+    Long orderId,
+    Long bookId,
+    int quantity,
+    int itemPrice
+) {
+
+  public static GetOrderRespDto from(OrderItem orderItem) {
+    return GetOrderRespDto.builder()
+        .orderId(orderItem.getOrder().getOrderId())
+        .bookId(orderItem.getBook().getBookId())
+        .quantity(orderItem.getQuantity())
+        .itemPrice(orderItem.getItemPrice())
+        .build();
+  }
+}

--- a/src/main/java/com/study/bookstore/domain/order/service/GetOrderListService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/GetOrderListService.java
@@ -1,7 +1,9 @@
 package com.study.bookstore.domain.order.service;
 
 import com.study.bookstore.domain.order.dto.resp.GetOrderListRespDto;
+import com.study.bookstore.domain.order.entity.Order;
 import com.study.bookstore.domain.order.entity.repository.OrderRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/study/bookstore/domain/order/service/GetOrderService.java
+++ b/src/main/java/com/study/bookstore/domain/order/service/GetOrderService.java
@@ -1,0 +1,37 @@
+package com.study.bookstore.domain.order.service;
+
+import com.study.bookstore.domain.order.dto.resp.GetOrderRespDto;
+import com.study.bookstore.domain.order.entity.Order;
+import com.study.bookstore.domain.order.entity.repository.OrderRepository;
+import com.study.bookstore.domain.orderItem.entity.OrderItem;
+import com.study.bookstore.domain.orderItem.entity.repository.OrderItemRepository;
+import com.study.bookstore.domain.user.entity.User;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class GetOrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderItemRepository orderItemRepository;
+
+  public List<GetOrderRespDto> getOrder(Long orderId, User user) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new NoSuchElementException("해당 ID의 주문이 존재하지 않습니다."));
+
+    if (!order.getUser().getUserId().equals(user.getUserId())) {
+      throw new RuntimeException("권한이 없습니다.");
+    }
+
+    return orderItemRepository.findAllByOrder_orderId(orderId)
+        .stream().map(GetOrderRespDto::from)
+        .toList();
+
+
+  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
주문 상세조회 기능을 구현했습니다. 
유저가 주문번호를 입력하여 해당 주문의 상세 정보를 조회할 수 있도록 했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 변경사항 1 : 주문 상세 조회 기능 - 유저가 주문번호를 입력하면 해당 주문의 정보를 조회
                           (유저가 입력한 주문번호와 유저 ID를 기반으로 주문 정보를 조회합니다.)

---

## 📌 참고 사항 (Additional Notes)

