### PR TITLE
Feat:카테고리 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/study/bookstore/domain/book/controller/BookController.java
+++ b/src/main/java/com/study/bookstore/domain/book/controller/BookController.java
@@ -5,6 +5,7 @@ import com.study.bookstore.domain.book.dto.req.UpdateBookReqDto;
 import com.study.bookstore.domain.book.dto.resp.GetBookRespDto;
 import com.study.bookstore.domain.book.entity.Book;
 import com.study.bookstore.domain.book.entity.repository.BookRepository;
+import com.study.bookstore.domain.book.facade.BookFacade;
 import com.study.bookstore.domain.book.service.CreateBookService;
 import com.study.bookstore.domain.book.service.GetBookListService;
 import com.study.bookstore.domain.book.service.InventoryService;
@@ -46,16 +47,7 @@ import com.study.bookstore.domain.user.entity.User;
 @RequiredArgsConstructor
 public class BookController {
 
-  private final CreateBookService createBookService;
-  private final GetBookListService getBookListService;
-  private final DeleteBookService DeleteBookService;
-  private final UpdateBookService updateBookService;
-  private final GetBookDetailService GetBookDetailService;
-  private final InventoryService inventoryService;
-  private final SearchBookService searchBookService;
-  private final CategoryRepository categoryRepository;
-  private final BookRepository bookRepository;
-
+  private final BookFacade bookFacade;
 
   @Operation(summary = "책 추가", description = "책 추가 시 관리자만 가능")
   @PostMapping("/categories/{categoryId}")
@@ -64,24 +56,20 @@ public class BookController {
 
     //유저 객체에 세션정보를 받아온다.
     User user = (User) session.getAttribute("user");
-
     //유저가 널 값이거나 세션에 로그인 정보가 없는 경우
     if (user == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요.");
     }
     //1. 유저의 타입을 확인
     UserType userType = user.getUserType();
-
     //유저가 고객인 경우에는 권한이 없습니다.
     if (userType == null || userType == UserType.USER) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한이 없습니다.");
     }
     //관리자인 경우에는 책 추가 가능
     else {
-
       try {
-        // 서비스에서 책 추가 처리
-        createBookService.addBook(categoryId, req);
+        bookFacade.createBook(categoryId, req);
         return ResponseEntity.ok().body("책 추가가 완료되었습니다.");
       } catch (Exception e) {
         // 예외 처리
@@ -89,23 +77,20 @@ public class BookController {
       }
     }
   }
-
   @Operation(summary = "책 목록", description = "책 목록을 확인합니다.")
   @GetMapping
   public ResponseEntity<List<GetBookRespDto>> getBookList(
       @RequestParam(name = "pageNumber", defaultValue = "1") int pageNumber,
       @RequestParam(name = "pageSize", defaultValue = "10") int pageSize) {
-    List<GetBookRespDto> bookList = getBookListService.getBookList(pageNumber, pageSize);
+    List<GetBookRespDto> bookList = bookFacade.getBookList(pageNumber, pageSize);
     return ResponseEntity.ok(bookList);
   }
-
   @Operation(summary = "책 상세 조회", description = "책의 상세 정보를 확인합니다.")
   @GetMapping("{bookId}")
   public ResponseEntity<GetBookRespDto> getBookDetail(@PathVariable Long bookId) {
-    GetBookRespDto bookDetail = GetBookDetailService.getBookDetail(bookId);
+    GetBookRespDto bookDetail = bookFacade.getBookListDetail(bookId);
     return ResponseEntity.ok(bookDetail);
   }
-
   @Operation(summary = "책 삭제", description = "책 삭제 관리자만 가능")
   @DeleteMapping("{bookId}")
   public ResponseEntity<String> deleteBook(@PathVariable Long bookId, HttpSession session) {
@@ -114,13 +99,11 @@ public class BookController {
     if (user == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요");
     }
-
     UserType userType = user.getUserType();
-
     if (userType == null || userType.equals(UserType.USER)) { // UserType은 enum으로 가정
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("삭제 권한이 없습니다.");
     } else {
-      DeleteBookService.deleteBook(bookId);
+      bookFacade.deleteBook(bookId);
       return ResponseEntity.ok().body("책 삭제가 완료되었습니다.");
     }
   }
@@ -133,7 +116,6 @@ public class BookController {
     //로그인 여부 확인
     if (user == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요.");
-
     }
     //유저 권한 확인
     UserType userType = user.getUserType();
@@ -141,12 +123,10 @@ public class BookController {
     if (userType == null || userType.equals(UserType.USER)) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("수정 권한이 없습니다.");
     } else {
-      updateBookService.updateBook(req, bookId);
+      bookFacade.updateBook(req, bookId);
       return ResponseEntity.ok().body("책 수정이 완료 되었습니다.");
     }
-
   }
-
   @Operation(summary = "책 재고 확인", description = "단순 재고 확인")
   @GetMapping("/inventory/{bookId}")
   public ResponseEntity<Integer> getBookInventory(@PathVariable Long bookId, HttpSession session) {
@@ -159,10 +139,9 @@ public class BookController {
     if (userType == null || userType.equals(UserType.USER)) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body(0);
     }
-    int stock = inventoryService.getInventory(bookId);
+    int stock = bookFacade.getBookInventory(bookId);
     return ResponseEntity.ok(stock);
   }
-
   @Operation(summary = "책 재고 추가")
   @PostMapping("/inventory/add/{bookId}")
   public ResponseEntity<String> addBookInventory(@PathVariable Long bookId, HttpSession session,
@@ -176,7 +155,7 @@ public class BookController {
     if (userType == null || userType.equals(UserType.USER)) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("확인 권한이 없습니다.");
     }
-    int stock = inventoryService.addInventory(bookId, addBookAmount);
+    int stock = bookFacade.addBookInventory(bookId, addBookAmount);
     return ResponseEntity.ok("재고가 추가되었습니다.");
   }
 
@@ -193,7 +172,7 @@ public class BookController {
     if (userType == null || userType.equals(UserType.USER)) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("확인 권한이 없습니다.");
     }
-    int stock = inventoryService.removeInventory(bookId, removeBookAmount);
+    int stock = bookFacade.removeBookInventory(bookId, removeBookAmount);
     return ResponseEntity.ok("재고가 삭제 되었습니다.");
   }
 
@@ -208,10 +187,8 @@ public class BookController {
   ) {
     // Pageable 객체 생성 (페이지, 크기, 정렬)
     Pageable pageable = PageRequest.of(page, size, Sort.by(sort).ascending());
-
     // Service로 pageable 전달
-    Page<Book> books = searchBookService.getBooks(categoryId, search, pageable);
-
+    Page<Book> books = bookFacade.searchBooks(categoryId, search, pageable);
     // 필요한 데이터만 맵으로 반환
     Map<String, Object> response = new HashMap<>();
     response.put("books", books.getContent());  // 책 목록

--- a/src/main/java/com/study/bookstore/domain/book/entity/Book.java
+++ b/src/main/java/com/study/bookstore/domain/book/entity/Book.java
@@ -2,6 +2,7 @@ package com.study.bookstore.domain.book.entity;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.study.bookstore.domain.book.dto.req.UpdateBookReqDto;
 import com.study.bookstore.domain.category.entity.Category;
 import com.study.bookstore.domain.review.entity.Review;

--- a/src/main/java/com/study/bookstore/domain/book/facade/BookFacade.java
+++ b/src/main/java/com/study/bookstore/domain/book/facade/BookFacade.java
@@ -1,0 +1,67 @@
+package com.study.bookstore.domain.book.facade;
+
+import com.study.bookstore.domain.book.dto.req.CreateBookReqDto;
+import com.study.bookstore.domain.book.dto.req.UpdateBookReqDto;
+import com.study.bookstore.domain.book.dto.resp.GetBookRespDto;
+import com.study.bookstore.domain.book.entity.Book;
+import com.study.bookstore.domain.book.service.CreateBookService;
+import com.study.bookstore.domain.book.service.GetBookListService;
+import com.study.bookstore.domain.book.service.InventoryService;
+import com.study.bookstore.domain.book.service.SearchBookService;
+import com.study.bookstore.domain.book.service.UpdateBookService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BookFacade {
+
+  private final CreateBookService createBookService;
+  private final GetBookListService getBookListService;
+  private final com.study.bookstore.domain.book.service.DeleteBookService DeleteBookService;
+  private final UpdateBookService updateBookService;
+  private final com.study.bookstore.domain.book.service.GetBookDetailService GetBookDetailService;
+  private final InventoryService inventoryService;
+  private final SearchBookService searchBookService;
+
+  //책 추가
+  public void createBook(Long categoryId, CreateBookReqDto req){
+    createBookService.addBook(categoryId, req);
+  }
+  //책 목록
+  public List<GetBookRespDto> getBookList(int pageNumber, int pageSize){
+    return getBookListService.getBookList(pageNumber, pageSize);
+  }
+  //책 상세 조회
+  public GetBookRespDto getBookListDetail(Long bookId){
+    return GetBookDetailService.getBookDetail(bookId);
+  }
+  //책 삭제
+  public void deleteBook(Long bookId){
+    DeleteBookService.deleteBook(bookId);
+  }
+  //책 수정
+  public void updateBook(UpdateBookReqDto req, Long bookId){
+    updateBookService.updateBook(req, bookId);
+  }
+  //책 재고 확인
+  public int getBookInventory(Long bookId){
+    return inventoryService.getInventory(bookId);
+  }
+  //책 재고 추가
+  public int addBookInventory(Long bookId, int addBookAmount){
+    return inventoryService.addInventory(bookId, addBookAmount);
+  }
+  //책 재고 삭제
+  public int removeBookInventory(Long bookId, int removeBookAmount){
+    return inventoryService.removeInventory(bookId, removeBookAmount);
+  }
+  //책 카테고리 검색 및 정렬 기능
+  public Page<Book> searchBooks(Long categoryId, String search, Pageable pageable){
+    return searchBookService.getBooks(categoryId, search, pageable);
+  }
+
+}

--- a/src/main/java/com/study/bookstore/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/study/bookstore/domain/category/controller/CategoryController.java
@@ -1,9 +1,11 @@
 package com.study.bookstore.domain.category.controller;
 
 import com.study.bookstore.domain.category.dto.req.CreateCategoryReqDto;
+import com.study.bookstore.domain.category.dto.resp.GetCategoryListRespDto;
 import com.study.bookstore.domain.category.facade.CategoryFacade;
 import com.study.bookstore.domain.category.service.CreateCategoryService;
 import com.study.bookstore.domain.category.service.DeleteCategoryService;
+import com.study.bookstore.domain.category.service.GetDetailCategoryService;
 import com.study.bookstore.domain.category.service.UpdateCategoryService;
 import com.study.bookstore.domain.user.entity.User;
 import com.study.bookstore.domain.user.entity.UserType;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CategoryController {
 
   private final CategoryFacade categoryFacade;
+  private final GetDetailCategoryService getDetailCategoryService;
 
   @Operation(summary = "카테고리 추가")
   @PostMapping
@@ -75,6 +79,25 @@ public class CategoryController {
     } else {
       categoryFacade.deleteCategory(categoryId);
       return ResponseEntity.ok().body("카테고리 삭제 완료");
+    }
+  }
+  @Operation(summary = "카테고리 상세 조회")
+  @GetMapping("/{categoryId}")
+  public ResponseEntity<?> getCategoryDetail(@PathVariable Long categoryId, HttpSession session) {
+    User user = (User) session.getAttribute("user");
+    if (user == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요.");
+    }
+    UserType userType = user.getUserType();
+    if (userType == null || userType == UserType.USER) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한이 없습니다.");
+    }
+    try {
+      GetCategoryListRespDto catetoryDetail = getDetailCategoryService.getCategoryDetail(
+          categoryId);
+      return ResponseEntity.ok(catetoryDetail);
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
   }
 }

--- a/src/main/java/com/study/bookstore/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/study/bookstore/domain/category/controller/CategoryController.java
@@ -1,6 +1,7 @@
 package com.study.bookstore.domain.category.controller;
 
 import com.study.bookstore.domain.category.dto.req.CreateCategoryReqDto;
+import com.study.bookstore.domain.category.facade.CategoryFacade;
 import com.study.bookstore.domain.category.service.CreateCategoryService;
 import com.study.bookstore.domain.category.service.DeleteCategoryService;
 import com.study.bookstore.domain.category.service.UpdateCategoryService;
@@ -27,9 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CategoryController {
 
-  private final CreateCategoryService createCategoryService;
-  private final UpdateCategoryService updateCategoryService;
-  private final DeleteCategoryService deleteCategoryService;
+  private final CategoryFacade categoryFacade;
 
   @Operation(summary = "카테고리 추가")
   @PostMapping
@@ -43,7 +42,7 @@ public class CategoryController {
     if (userType == null || userType == UserType.USER) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한이 없습니다.");
     } else {
-      createCategoryService.addCategory(req);
+      categoryFacade.addCategory(req);
       return ResponseEntity.ok().body("카테고리  추가 완료");
     }
   }
@@ -59,7 +58,7 @@ public class CategoryController {
     if (userType == null || userType == UserType.USER) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한이 없습니다.");
     } else {
-      updateCategoryService.updateCategory(categoryName, categoryId);
+      categoryFacade.updateCategory(categoryName, categoryId);
       return ResponseEntity.ok().body("카테고리 수정 완료");
     }
   }
@@ -74,7 +73,7 @@ public class CategoryController {
     if (userType == null || userType == UserType.USER) {
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("권한이 없습니다.");
     } else {
-      deleteCategoryService.deleteCategory(categoryId);
+      categoryFacade.deleteCategory(categoryId);
       return ResponseEntity.ok().body("카테고리 삭제 완료");
     }
   }

--- a/src/main/java/com/study/bookstore/domain/category/dto/resp/GetCategoryListRespDto.java
+++ b/src/main/java/com/study/bookstore/domain/category/dto/resp/GetCategoryListRespDto.java
@@ -1,0 +1,17 @@
+package com.study.bookstore.domain.category.dto.resp;
+
+import com.study.bookstore.domain.category.entity.Category;
+
+public record GetCategoryListRespDto(
+    Long categoryId,
+    String categoryName
+) {
+
+    //Category엔티티를 DTO로 변환하는 메서드
+    public static GetCategoryListRespDto of(Category category){
+      return new GetCategoryListRespDto(
+          category.getCategoryId(),
+          category.getCategoryName()
+      );
+    }
+}

--- a/src/main/java/com/study/bookstore/domain/category/entity/repository/CategoryRepository.java
+++ b/src/main/java/com/study/bookstore/domain/category/entity/repository/CategoryRepository.java
@@ -8,6 +8,4 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
   //id는 카테고리의 고유 식별자인 categoryId와 같은 역할
   Optional<Category> findById(Long id);
-
-
 }

--- a/src/main/java/com/study/bookstore/domain/category/facade/CategoryFacade.java
+++ b/src/main/java/com/study/bookstore/domain/category/facade/CategoryFacade.java
@@ -1,0 +1,32 @@
+package com.study.bookstore.domain.category.facade;
+
+import com.study.bookstore.domain.category.dto.req.CreateCategoryReqDto;
+import com.study.bookstore.domain.category.service.CreateCategoryService;
+import com.study.bookstore.domain.category.service.DeleteCategoryService;
+import com.study.bookstore.domain.category.service.UpdateCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryFacade {
+
+  private final CreateCategoryService createCategoryService;
+  private final UpdateCategoryService updateCategoryService;
+  private final DeleteCategoryService deleteCategoryService;
+
+  //카테고리 추가
+  public void addCategory(CreateCategoryReqDto req) {
+    createCategoryService.addCategory(req);
+  }
+  //카테고리 수정
+  public void updateCategory(String categoryName, Long categoryId) {
+    updateCategoryService.updateCategory(categoryName, categoryId);
+  }
+  //카테고리 삭제
+  public void deleteCategory(Long categoryId){
+    deleteCategoryService.deleteCategory(categoryId);
+  }
+}
+
+

--- a/src/main/java/com/study/bookstore/domain/category/service/CreateCategoryService.java
+++ b/src/main/java/com/study/bookstore/domain/category/service/CreateCategoryService.java
@@ -14,10 +14,10 @@ public class CreateCategoryService {
 
   private final CategoryRepository categoryRepository;
 
-  public Category addCategory(CreateCategoryReqDto req) {
+  public void addCategory(CreateCategoryReqDto req) {
 
     Category category = req.of();
-    return categoryRepository.save(category);
+    categoryRepository.save(category);
 
   }
 

--- a/src/main/java/com/study/bookstore/domain/category/service/GetDetailCategoryService.java
+++ b/src/main/java/com/study/bookstore/domain/category/service/GetDetailCategoryService.java
@@ -1,0 +1,23 @@
+package com.study.bookstore.domain.category.service;
+
+import com.study.bookstore.domain.book.dto.resp.GetBookRespDto;
+import com.study.bookstore.domain.category.dto.resp.GetCategoryListRespDto;
+import com.study.bookstore.domain.category.entity.Category;
+import com.study.bookstore.domain.category.entity.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class GetDetailCategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public GetCategoryListRespDto getCategoryDetail(Long categoryId){
+      Category category = categoryRepository.findById(categoryId)
+          .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+      return GetCategoryListRespDto.of(category);
+    }
+}

--- a/src/main/java/com/study/bookstore/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/study/bookstore/domain/review/controller/ReviewController.java
@@ -8,6 +8,7 @@ import com.study.bookstore.domain.review.dto.req.UpdateReviewReqDto;
 import com.study.bookstore.domain.review.dto.resp.AllReviewListRespDto;
 import com.study.bookstore.domain.review.dto.resp.ReviewListRespDto;
 import com.study.bookstore.domain.review.entity.Review;
+import com.study.bookstore.domain.review.facade.ReviewFacade;
 import com.study.bookstore.domain.review.service.AllListReviewService;
 import com.study.bookstore.domain.review.service.CreateReviewService;
 import com.study.bookstore.domain.review.service.DeleteReviewService;
@@ -43,11 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReviewController {
 
-  private final CreateReviewService createReviewService;
-  private final DeleteReviewService deleteReviewService;
-  private final UpdateReviewService updateReviewService;
-  private final ListReviewService listReviewService;
-  private final AllListReviewService allListReviewService;
+  private final ReviewFacade reviewFacade;
 
   @Operation(summary = "리뷰 작성")
   @PostMapping
@@ -59,7 +56,7 @@ public class ReviewController {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요");
     }
     try {
-      createReviewService.createReview(req, user);  // req와 user 전달
+      reviewFacade.createReview(req, user);  // req와 user 전달
       return ResponseEntity.ok("리뷰가 성공적으로 작성되었습니다.");
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -75,7 +72,7 @@ public class ReviewController {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요");
     }
     try {
-      deleteReviewService.deleteReview(reviewId, user);
+      reviewFacade.deleteReview(reviewId, user);
       return ResponseEntity.ok("리뷰가 성공적으로 삭제되었습니다.");
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -85,14 +82,14 @@ public class ReviewController {
   @Operation(summary = "리뷰 수정")
   @PutMapping("/{reviewId}")
   public ResponseEntity<String> updateReview(@PathVariable Long reviewId,
-      @RequestBody UpdateReviewReqDto updateReviewReqDto, HttpSession session) {
+      @RequestBody UpdateReviewReqDto req, HttpSession session) {
     User user = (User) session.getAttribute("user");
     if (user == null) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 해주세요");
     }
     try {
       // DTO 객체와 로그인한 사용자 객체를 서비스 메서드에 넘김
-      updateReviewService.updateReview(reviewId, updateReviewReqDto, user);
+      reviewFacade.updateReview(reviewId, req, user);
 
       return ResponseEntity.ok("리뷰가 성공적으로 수정되었습니다.");
 
@@ -104,7 +101,7 @@ public class ReviewController {
   @Operation(summary = "특정 책에 대한 리뷰 확인")
   @GetMapping("/books/{bookId}/reviews")
   public List<ReviewListRespDto> reviewList(@PathVariable Long bookId) {
-    List<ReviewListRespDto> reviews = listReviewService.getReviewsForBook(bookId);
+    List<ReviewListRespDto> reviews = reviewFacade.getReviewsForBook(bookId);
     return reviews;
   }
   @Operation(summary = "전체 리뷰 확인")
@@ -119,7 +116,7 @@ public class ReviewController {
     Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
 
     //서비스에서 리뷰 목록 가져오기
-    Page<AllReviewListRespDto>reviews = allListReviewService.getAllReviews(pageable);
+    Page<AllReviewListRespDto>reviews = reviewFacade.getAllReviews(pageable);
     return ResponseEntity.ok(reviews);
   }
 

--- a/src/main/java/com/study/bookstore/domain/review/entity/Review.java
+++ b/src/main/java/com/study/bookstore/domain/review/entity/Review.java
@@ -1,5 +1,6 @@
 package com.study.bookstore.domain.review.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.study.bookstore.domain.book.entity.Book;
 import com.study.bookstore.domain.user.entity.User;
 import com.study.bookstore.global.entity.BaseTimeEntity;

--- a/src/main/java/com/study/bookstore/domain/review/facade/ReviewFacade.java
+++ b/src/main/java/com/study/bookstore/domain/review/facade/ReviewFacade.java
@@ -1,0 +1,50 @@
+package com.study.bookstore.domain.review.facade;
+
+import com.study.bookstore.domain.review.dto.req.CreateReviewReqDto;
+import com.study.bookstore.domain.review.dto.req.UpdateReviewReqDto;
+import com.study.bookstore.domain.review.dto.resp.AllReviewListRespDto;
+import com.study.bookstore.domain.review.dto.resp.ReviewListRespDto;
+import com.study.bookstore.domain.review.service.AllListReviewService;
+import com.study.bookstore.domain.review.service.CreateReviewService;
+import com.study.bookstore.domain.review.service.DeleteReviewService;
+import com.study.bookstore.domain.review.service.ListReviewService;
+import com.study.bookstore.domain.review.service.UpdateReviewService;
+import com.study.bookstore.domain.user.entity.User;
+import jakarta.persistence.Column;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewFacade {
+
+  private final CreateReviewService createReviewService;
+  private final DeleteReviewService deleteReviewService;
+  private final UpdateReviewService updateReviewService;
+  private final ListReviewService listReviewService;
+  private final AllListReviewService allListReviewService;
+
+  //리뷰 추가
+  public void createReview(CreateReviewReqDto req, User user){
+    createReviewService.createReview(req, user);  // req와 user 전달
+  }
+  //리뷰 삭제
+  public void deleteReview(Long reviewId, User user){
+    deleteReviewService.deleteReview(reviewId, user);
+  }
+  //리뷰 수정
+  public void updateReview(Long reviewId, UpdateReviewReqDto req, User user){
+    updateReviewService.updateReview(reviewId, req, user);
+  }
+  //특정 책에 대한 리뷰 확인
+  public List<ReviewListRespDto> getReviewsForBook(Long bookId){
+    return listReviewService.getReviewsForBook(bookId);
+  }
+  //전체 리뷰 확인
+  public Page<AllReviewListRespDto> getAllReviews(Pageable pageable){
+   return allListReviewService.getAllReviews(pageable);
+  }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
카테고리 ID를 기반으로 특정 카테고리를 상세 조회할 수 있는 기능을 추가했습니다. 이 기능은 관리자만 접근 가능하며, 로그인하지 않거나 권한이 없는 사용자는 요청이 제한됩니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
 카테고리 상세 조회 API 추가: /categories/{categoryId} 엔드포인트 구현
 권한 체크: 관리자 권한을 가진 사용자만 조회 가능하도록 제한
 DTO 정의: GetCategoryListRespDto를 통해 카테고리 ID와 이름 응답
---

## 📌 참고 사항 (Additional Notes)
추가적인 설명이나 주의해야 할 사항이 있다면 적어주세요.<br>
예: 의존성 추가, 환경 설정 변경 등.
