### PR TITLE
feat:책 삭제 로직 개선 및 isDeleted 컬럼 처리

### DIFF
--- a/src/main/java/com/study/bookstore/domain/book/controller/BookController.java
+++ b/src/main/java/com/study/bookstore/domain/book/controller/BookController.java
@@ -85,6 +85,7 @@ public class BookController {
     List<GetBookRespDto> bookList = bookFacade.getBookList(pageNumber, pageSize);
     return ResponseEntity.ok(bookList);
   }
+
   @Operation(summary = "책 상세 조회", description = "책의 상세 정보를 확인합니다.")
   @GetMapping("{bookId}")
   public ResponseEntity<GetBookRespDto> getBookDetail(@PathVariable Long bookId) {
@@ -102,9 +103,17 @@ public class BookController {
     UserType userType = user.getUserType();
     if (userType == null || userType.equals(UserType.USER)) { // UserType은 enum으로 가정
       return ResponseEntity.status(HttpStatus.FORBIDDEN).body("삭제 권한이 없습니다.");
-    } else {
-      bookFacade.deleteBook(bookId);
+    }
+
+    try {
+      bookFacade.deleteBook(bookId); //책 삭제 처리
       return ResponseEntity.ok().body("책 삭제가 완료되었습니다.");
+    }catch (IllegalStateException e){
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body("책 삭제 실패: " + e.getMessage());
+    }catch (Exception e){
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body("책 삭제 중 오류가 발생했습니다." + e.getMessage());
     }
   }
 

--- a/src/main/java/com/study/bookstore/domain/book/entity/Book.java
+++ b/src/main/java/com/study/bookstore/domain/book/entity/Book.java
@@ -78,14 +78,31 @@ public class Book extends BaseTimeEntity {
   @Comment("책 코드")
   private String isbn;
 
-  @ManyToOne(cascade = CascadeType.ALL) // 카테고리가 삭제될 때 책도 삭제됨 category_id라는 칼럼이 추가되어, Category와 연결될 수 있게 한다.
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "category_id",  nullable = false) // FK 설정
   @JsonIgnore // 순환 참조 방지
   private Category category; // 카테고리와 객체 자체와 연결되며, 이를 통해 Book 클래스에서 카테고리의 이름이나 설명 같은 속성에 바로 접근할 수 있게 함.
 
   // 리뷰와의 관계 설정 (책 삭제 시 리뷰도 함께 삭제)
-  @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  private List<Review> reviews;// 하나의 책에 여러 개의 리뷰가 연결됨
+  @OneToMany(mappedBy = "book", fetch = FetchType.LAZY)
+  private List<Review> reviews;
+
+  //논리적 삭제 상태를 추가
+  @Builder.Default
+  @Column(name = "is_deleted", nullable = false)
+  private boolean isDeleted = false;
+
+  //책을 논리적으로 삭제하는 메서드
+  public void markAsDeleted(){
+    if(this.isDeleted){
+      throw new IllegalStateException("이미 삭제된 책입니다.");
+    }
+    this.isDeleted = true;
+  }
+  //책 상태를 삭제됨으로 변경하는 메서드
+  public void markAsRestored(){
+    this.isDeleted = false;
+  }
 
   public void setStock(int stock) {
     this.stock = stock; // stock 값을 설정하는 메서드

--- a/src/main/java/com/study/bookstore/domain/book/entity/repository/BookRepository.java
+++ b/src/main/java/com/study/bookstore/domain/book/entity/repository/BookRepository.java
@@ -20,7 +20,7 @@ public interface BookRepository extends JpaRepository<Book, Long> {
   // 전체 책 목록을 페이징 처리하여 가져오는 메서드
   Page<Book> findAll(Pageable pageable);
 
-  // categoryId와 search 조건으로 책을 검색하는 메서드
+ // categoryId와 search 조건으로 책을 검색하는 메서드
       @Query( "SELECT b FROM Book b WHERE " +
               "(:categoryId IS NULL OR b.category.categoryId = :categoryId) AND " +
               "(:search IS NULL OR LOWER(b.title) LIKE LOWER(CONCAT('%', :search, '%')) "
@@ -28,6 +28,8 @@ public interface BookRepository extends JpaRepository<Book, Long> {
       Page<Book> findBooks( @Param("categoryId") Long categoryId,
                             @Param("search") String search, Pageable pageable);
 }
+
+
 /*(:categoryId IS NULL OR b.category.categoryId = :categoryId):
 categoryId가 null이면 필터링을 하지 않음. categoryId가 주어지면 해당 카테고리의 책만 반환
 (:search IS NULL OR LOWER(b.title) LIKE LOWER(CONCAT('%', :search, '%')) OR LOWER(b.author) LIKE LOWER(CONCAT('%', :search, '%'))):

--- a/src/main/java/com/study/bookstore/domain/book/service/DeleteBookService.java
+++ b/src/main/java/com/study/bookstore/domain/book/service/DeleteBookService.java
@@ -1,5 +1,7 @@
 package com.study.bookstore.domain.book.service;
 
+import ch.qos.logback.core.CoreConstants;
+import com.study.bookstore.domain.book.entity.Book;
 import com.study.bookstore.domain.book.entity.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,8 +15,21 @@ public class DeleteBookService {
   private final BookRepository bookRepository;
 
   //책 아이디를 받아서 책 삭제
-  public void deleteBook(Long bookId) {
-    bookRepository.deleteById(bookId);
+  public String deleteBook(Long bookId) {
+
+    //책 찾기
+    Book book = bookRepository.findById(bookId)
+        .orElseThrow(() -> new RuntimeException("책을 찾을 수 없습니다"));
+
+    //논리적 삭제 상태 확인
+    if (book.isDeleted()) {
+      throw new IllegalStateException("이미 삭제된 책 입니다.");
+    }
+    //논리적 삭제 처리
+    book.markAsDeleted(); //idDeleted를 true로 설정
+    bookRepository.save(book);//저장
+
+    return "책이 삭제되었습니당";
   }
 
 }

--- a/src/main/java/com/study/bookstore/domain/review/entity/Review.java
+++ b/src/main/java/com/study/bookstore/domain/review/entity/Review.java
@@ -37,11 +37,11 @@ public class Review extends BaseTimeEntity {
   @Column(name = "review_id")
   private Long reviewId;
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "book_id", nullable = false)
   private Book book;
 
-  @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
@@ -50,6 +50,15 @@ public class Review extends BaseTimeEntity {
 
   @Column(columnDefinition = "TEXT", nullable = false)
   private String content;
+
+  @Builder.Default
+  @Column(name = "is_deleted", nullable = false)
+  private boolean isDeleted = false; // 기본값 false설정
+
+  //리뷰를 논리적으로 삭제하는 메서드
+  public void markAsDeleted(){
+    this.isDeleted = true;
+  }
 
   public void setContent(String content) {
     this.content=content;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     name: basic
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 📝 설명 (Description)
이번 PR에서는 책 삭제 기능에 논리적 삭제 상태를 처리하기 위해 isDeleted 컬럼을 추가하고, 책 삭제 시 isDeleted 상태를 업데이트하는 로직을 구현했습니다. 이를 통해 실제로 책 데이터를 삭제하지 않고, 논리적으로 삭제된 상태를 관리할 수 있게 됩니다.



--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- Book 엔티티: isDeleted 컬럼 추가 및 markAsDeleted, markAsRestored 메서드 구현.
- DeleteBookService: 책 삭제 시 isDeleted 값을 체크하고, 이미 삭제된 책에 대해 적절한 메시지를 반환하는 로직 추가.
 Controller: 책 삭제 API 호출 시 삭제 권한을 확인하고, 삭제 결과를 클라이언트에 반환하는 로직 추가.

---

## 📌 참고 사항 (Additional Notes)

책 삭제 시 isDeleted 상태로 변경되므로, 실제로 데이터베이스에서 책이 삭제되지 않고, 삭제된 상태로 관리됩니다.
삭제된 책에 대해서는 다시 복구할 수 있는 기능도 추가 가능.
isDeleted가 true인 경우 해당 책은 검색 결과나 목록에 포함되지 않도록 추가적인 처리가 필요할 수 있음.
