### PR TITLE
feat: 주문생성 기능에 jwt토큰을 활용한 권한확인 기능 추가

### DIFF
--- a/src/main/java/com/study/bookstore/domain/order/entity/Order.java
+++ b/src/main/java/com/study/bookstore/domain/order/entity/Order.java
@@ -1,5 +1,6 @@
 package com.study.bookstore.domain.order.entity;
 
+import com.study.bookstore.domain.member.entity.Member;
 import com.study.bookstore.domain.orderItem.entity.OrderItem;
 import com.study.bookstore.domain.user.entity.User;
 import com.study.bookstore.global.entity.BaseTimeEntity;
@@ -37,9 +38,19 @@ public class Order extends BaseTimeEntity {
   private Long orderId;
 
   @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  // 한 명의 유저는 여러개의 주문을 가질 수 있다.
+  @JoinColumn(name = "user_id")
+  private User user;
+  /*
+  @ManyToOne(fetch = FetchType.LAZY)
   // 한 명의 유저는 여러개의 주문을 가질 수 있다.
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
+  */
 
   @Column(name = "total_amount", nullable = false)
   private int totalAmount;

--- a/src/main/java/com/study/bookstore/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/study/bookstore/domain/order/facade/OrderFacade.java
@@ -2,6 +2,8 @@ package com.study.bookstore.domain.order.facade;
 
 import com.study.bookstore.domain.book.entity.Book;
 import com.study.bookstore.domain.book.service.ReadBookService;
+import com.study.bookstore.domain.member.entity.Member;
+import com.study.bookstore.domain.member.service.read.ReadMemberService;
 import com.study.bookstore.domain.order.dto.resp.GetOrderListRespDto;
 import com.study.bookstore.domain.order.dto.resp.GetOrderRespDto;
 import com.study.bookstore.domain.order.entity.Order;
@@ -37,7 +39,25 @@ public class OrderFacade {
   private final CreateOrderItemService createOrderItemService;
   private final ReadBookService readBookService;
   private final ReadOrderItemService readOrderItemService;
+  private final ReadMemberService readMemberService;
 
+  public Long createOrder(PaymentMethod paymentMethod, Member member) {
+    try {
+      Order order = Order.builder()
+          .member(member)
+          .paymentMethod(paymentMethod)
+          .totalAmount(-1)
+          .build();
+
+      Order saveOrder = createOrderService.createOrder(order);
+
+      return saveOrder.getOrderId();
+    } catch (IllegalArgumentException e) {
+      log.error("** 입력값 검증 실패 : {} **", e.getMessage());
+      throw new RuntimeException("주문 생성 중 오류가 발생하였습니다.", e);
+    }
+  }
+  /*
   public Long createOrder(PaymentMethod paymentMethod, User user) {
     try {
       Order order = Order.builder()
@@ -54,6 +74,7 @@ public class OrderFacade {
       throw new RuntimeException("주문 생성 중 오류가 발생하였습니다.", e);
     }
   }
+  */
 
   public void updateTotalAmount(Long orderId, int totalAmount) {
     try {
@@ -231,5 +252,9 @@ public class OrderFacade {
     } catch (Exception e) {
       throw new RuntimeException("주문 상세 조회 중 오류가 발생하였습니다.", e);
     }
+  }
+
+  public Member getMemberByEmail(String email) {
+    return readMemberService.findMemberByEmail(email);
   }
 }

--- a/src/main/java/com/study/bookstore/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/study/bookstore/global/config/security/SecurityConfig.java
@@ -50,10 +50,13 @@ public class SecurityConfig {
         .addFilterBefore(new JwtFilter(customUserDetailsService, jwtUtil), UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(c -> c.authenticationEntryPoint((AuthenticationEntryPoint))
             .accessDeniedHandler(AccessDeniedHandler))
-        .authorizeHttpRequests(c -> c.requestMatchers(AUTH_WHITELIST).permitAll()
-            .anyRequest().permitAll())
+        // .authorizeHttpRequests() : 이 부분에 url경로와 허용 권한을 지정
+        .authorizeHttpRequests(c -> c
+            .requestMatchers(AUTH_WHITELIST).permitAll()  // 인증이 필요없는 url => 모두 허용
+            //.requestMatchers("/book/categories/{categoryId}").hasRole("ADMIN")  // 책 추가는 role이 ADMIN인 member만 가능
+            .requestMatchers("/order/orders").hasAnyRole("ADMIN", "USER") // 책 주문은 role이 ADMIN, USER인 member만 가능
+            //.anyRequest().authenticated())  // 그 외 요청은 로그인된 사용자만 접근 가능
+            .anyRequest().permitAll())   // 그 외 요청 모두 접근 가능 (로그인을 하지 않아도 모든 요청을 허용 => 보안을 위해 하지 않는 것이 좋다)
         .build();
   }
-
-
 }

--- a/src/main/java/com/study/bookstore/web/api/member/MemberApiController.java
+++ b/src/main/java/com/study/bookstore/web/api/member/MemberApiController.java
@@ -78,6 +78,7 @@ public class MemberApiController {
     log.info("** expTime : {} **", expTime);
 
     tokenBlacklistService.createTokenBlacklist(token, expTime);
+    request.getSession().removeAttribute("cart");
 
     return ResponseEntity.ok().body("로그아웃 성공");
   }


### PR DESCRIPTION
## 📝 설명 (Description)
주문 생성 기능에 JWT 토큰을 활용한 권한 확인 기능을 추가했습니다. 
사용자가 주문을 생성하려면 유효한 JWT 토큰을 헤더에 포함해야 하며, 
해당 토큰이 블랙리스트에 포함되지 않은 경우에만 주문을 진행할 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ] 변경사항 1 : JWT 토큰 검증 기능 추가 - 주문 생성 요청 시 Authorization 헤더에서 JWT 토큰을 추출하여 유효성을 검사합니다.
- [ ] 변경사항 2 : 블랙리스트 확인 - 블랙리스트에 포함된 토큰을 가지고 있다면, "로그아웃된 계정입니다."라는 메시지를 반환합니다.
- [ ] 변경사항 3 : 책 주문은 user와 admin 역할을 가진 사용자 모두 가능합니다.
---

## 📌 참고 사항 (Additional Notes)
권한 확인을 위해 JWT 토큰을 반드시 Authorization 헤더에 Bearer <token> 형식으로 포함해야 합니다.
